### PR TITLE
Update javascript.vim

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -52,7 +52,7 @@ let s:line_block_suf_regex = '\%([\\*+/.,:]\|\W[|&?]\|||\|&&\)' . s:line_term
 
 " Regex suffix line block
 
-let s:one_line_scope_regex = '\%(\<\%(if\|else\|while\)\>[^{;]*\|=\%(>\)\=\|\<for\>.*\%(;\|{\)\@<!' . s:line_term . '\)' . s:line_term
+let s:one_line_scope_regex = '\%(\%(\<else\>\|\<\%(if\|for\|while\)\>\s*(\%([^()]*\|[^()]*(\%([^()]*\|[^()]*(\%([^()]*\|[^()]*([^()]*)[^()]*\))[^()]*\))[^()]*\))\)\|=\%(>\)\=\)' . s:line_term
 
 " Regex that defines start blocks.
 let s:block_start_regex = '\%({\|[\|(\)\s*' . s:line_term


### PR DESCRIPTION
this will detect the start and end parentheses after 'if,for,while',allowing statements with parentheses to come after the condition parens.This regex can detect with up to 4 levels of nesting.
sorry about the ugly regex,could it be shorter?
